### PR TITLE
Fix a bug and add whitespace

### DIFF
--- a/graphql.el
+++ b/graphql.el
@@ -41,10 +41,13 @@
    ((and (consp obj)
          (not (consp (cdr obj))))
     (symbol-name (car obj)))))
+
 (defun graphql--encode-argument-spec (spec)
   (graphql--encode-argument (car spec) (cdr spec)))
+
 (defun graphql--encode-argument (key value)
   (format "%s:%s" key (graphql--encode-argument-value value)))
+
 (defun graphql--encode-argument-value (value)
   (cond
    ((symbolp value)
@@ -59,6 +62,7 @@
     (number-to-string value))
    (t
     (graphql--encode value))))
+
 (defun graphql--encode-parameter-spec (spec)
   "Encode a parameter SPEC.
 SPEC is expected to be of the following form:
@@ -88,6 +92,7 @@ parameter."
                                (nth 1 spec)
                                nil
                                (nthcdr 2 spec))))
+
 (defun graphql--encode-parameter (name type &optional required default)
   (format "$%s:%s%s%s"
           (symbol-name name)

--- a/graphql.el
+++ b/graphql.el
@@ -61,7 +61,7 @@
    ((numberp value)
     (number-to-string value))
    (t
-    (graphql--encode value))))
+    (graphql-encode value))))
 
 (defun graphql--encode-parameter-spec (spec)
   "Encode a parameter SPEC.


### PR DESCRIPTION
You should also take care of this:

```
In toplevel form:
graphql.el:142:1:Warning: Unused lexical variable ‘key’
graphql.el:142:1:Warning: Unused lexical variable ‘value’
graphql.el:142:1:Warning: Unused lexical variable ‘symbol’
graphql.el:142:1:Warning: Unused lexical variable ‘key’
graphql.el:142:1:Warning: Unused lexical variable ‘value’
graphql.el:142:1:Warning: Unused lexical variable ‘symbol’
graphql.el:142:1:Warning: Unused lexical variable ‘key’
graphql.el:142:1:Warning: Unused lexical variable ‘value’
graphql.el:142:1:Warning: Unused lexical variable ‘symbol’
graphql.el:142:1:Warning: Unused lexical variable ‘key’
graphql.el:142:1:Warning: Unused lexical variable ‘value’
graphql.el:142:1:Warning: Unused lexical variable ‘symbol’
graphql.el:142:1:Warning: Unused lexical variable ‘symbol’
```

May I interest you in [`auto-compile`](https://github.com/emacscollective/auto-compile)?